### PR TITLE
Packages composer name

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ After initializing a fresh instance of Laravel (and making all the necessary con
 ### Via composer
 
 1. `Cd` to your Laravel app  
-2. Install this preset via `composer require laravel-frontend-presets/NowUi`. No need to register the service provider. Laravel 5.5 & up can auto detect the package.
+2. Install this preset via `composer require laravel-frontend-presets/now-ui-dashboard`. No need to register the service provider. Laravel 5.5 & up can auto detect the package.
 3. Run `php artisan preset nowui` command to install the Argon preset. This will install all the necessary assets and also the custom auth views, it will also add the auth route in `routes/web.php`
 (NOTE: If you run this command several times, be sure to clean up the duplicate Auth entries in routes/web.php)
 4. In your terminal run `composer dump-autoload`


### PR DESCRIPTION
edit packages composer name
`[InvalidArgumentException]                                                                       
  Could not find a matching version of package laravel-frontend-presets/NowUi. Check the package   
  spelling, your version constraint and that the package is available in a stability which matche  
  s your minimum-stability (dev).`
to
`composer require laravel-frontend-presets/now-ui-dashboard`